### PR TITLE
Add python 3.6 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - "2.7"
 - "3.4"
 - "3.5"
+- "3.6"
 - "nightly"
 install:
 - pip install -r requirements.txt


### PR DESCRIPTION
This PR adds ``py3.6`` to travis.
Currently, `nightly` points to ``py3.7dev``.